### PR TITLE
Add room_message and room_join events

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,13 @@ end
 
 ## Events
 
-The IRC adapter will trigger the `:connected` and `:disconnected` events when the robot has connected and disconnected from IRC, respectively. There is no payload data for either event.
+The IRC adapter will trigger these events:
+
+| Event                  | When                      | Payload                                |
+|------------------------|---------------------------|----------------------------------------|
+| `:connected`           | connected to IRC          | None                                   |
+| `:disconnected`        | disconnected from IRC     | None                                   |
+| `:user_joined_room`    | a user joins a room       | `user: Lita::User`, `room: Lita::Room` |
 
 ## License
 

--- a/lib/lita/adapters/irc/cinch_plugin.rb
+++ b/lib/lita/adapters/irc/cinch_plugin.rb
@@ -9,6 +9,7 @@ module Lita
         match /.*/
         listen_to :connect, method: :on_connect
         listen_to :invite, method: :on_invite
+        listen_to :join, method: :on_room_join
 
         def execute(m)
           body = get_body(m)
@@ -25,6 +26,14 @@ module Lita
         def on_invite(m)
           user = user_by_nick(m.user.nick)
           m.channel.join if robot.auth.user_is_admin?(user)
+        end
+
+        def on_room_join(m)
+          robot.trigger(
+            :user_joined_room,
+            user: user_by_nick(m.user.nick),
+            room: Lita::Room.find_by_name(m.channel.name),
+          )
         end
 
         private

--- a/spec/lita/adapters/irc/cinch_plugin_spec.rb
+++ b/spec/lita/adapters/irc/cinch_plugin_spec.rb
@@ -9,6 +9,7 @@ describe Lita::Adapters::IRC::CinchPlugin do
   let(:user) { double("Lita::User", name: "Carl") }
   let(:message) { double("Lita::Message", command!: nil, source: source) }
   let(:source) { double("Lita::Source", room: "#channel", user: user) }
+  let(:room) { double("Lita::Room", name: "#channel") }
   let(:m) do
     instance_double(
       "Cinch::Message",
@@ -79,6 +80,22 @@ describe Lita::Adapters::IRC::CinchPlugin do
     it "ignores the invite if it didn't come from an admin" do
       expect(invite_m.channel).not_to receive(:join)
       subject.on_invite(invite_m)
+    end
+  end
+
+  describe "#on_room_join" do
+    before do
+      allow(Lita::Room).to receive(:find_by_name).and_return(room)
+      allow(Lita::User).to receive(:find_by_name).and_return(user)
+    end
+
+    it "triggers a join event when someone joins a channel" do
+      expect(robot).to receive(:trigger).with(
+        :user_joined_room,
+        user: user,
+        room: room,
+      )
+      subject.on_room_join(m)
     end
   end
 end


### PR DESCRIPTION
In an ideal world, `user` and `sender` would have the same name but I can't figure out what that key should me named. Like the antonym of `target`. `source`?

Also, any ideas how to implement tests for this code?