### PR TITLE
Create or update a room when a user joins

### DIFF
--- a/lib/lita/adapters/irc/cinch_plugin.rb
+++ b/lib/lita/adapters/irc/cinch_plugin.rb
@@ -32,7 +32,7 @@ module Lita
           robot.trigger(
             :user_joined_room,
             user: user_by_nick(m.user.nick),
-            room: Lita::Room.find_by_name(m.channel.name),
+            room: Lita::Room.create_or_update(m.channel.name, name: m.channel.name),
           )
         end
 


### PR DESCRIPTION
Rooms are never created anywhere in lita-irc, so we need to do it if
we're going to use them.

As we discussed on IRC.