### PR TITLE
Add {de,}{voice,op} commands

### DIFF
--- a/lib/lita/adapters/irc.rb
+++ b/lib/lita/adapters/irc.rb
@@ -66,6 +66,30 @@ module Lita
         robot.trigger(:disconnected)
       end
 
+      def op(target, user)
+        channel = cinch.channel_list.find_ensured(target.room)
+        Lita.logger.debug("Oping user #{user} in channel #{target.room}")
+        channel.op(user)
+      end
+
+      def deop(target, user)
+        channel = cinch.channel_list.find_ensured(target.room)
+        Lita.logger.debug("Deoping user #{user} in channel #{target.room}")
+        channel.deop(user)
+      end
+
+      def voice(target, user)
+        channel = cinch.channel_list.find_ensured(target.room)
+        Lita.logger.debug("Voiceing user #{user} in channel #{target.room}")
+        channel.voice(user)
+      end
+
+      def devoice(target, user)
+        channel = cinch.channel_list.find_ensured(target.room)
+        Lita.logger.debug("Devoiceing user #{user} in channel #{target.room}")
+        channel.devoice(user)
+      end
+
       private
 
       def channels

--- a/spec/lita/adapters/irc_spec.rb
+++ b/spec/lita/adapters/irc_spec.rb
@@ -115,6 +115,16 @@ describe Lita::Adapters::IRC, lita: true do
     end
   end
 
+  describe "#op" do
+    it "ops a user in the room" do
+      source = instance_double("Lita::Source", room: "#foo")
+      channel = instance_double("Cinch::Channel")
+      expect(Cinch::Channel).to receive(:op).with("#foo", subject.cinch).and_return(channel)
+      expect(channel).to receive(:op).with("Carl")
+      subject.op(source, "Carl")
+    end
+  end
+
   describe "#shut_down" do
     it "disconnects from IRC" do
       expect(subject.cinch).to receive(:quit)


### PR DESCRIPTION
I don't think this is a pretty approach:

```ruby
        target = Source.new(room: payload[:room])
        robot.send(:adapter).op(target, payload[:user].name)
```

What I'd like is to is monkeypatch `Lita::Room` and add the commands there but I don't know how you feel about that.

```ruby      
        payload[:room].op(payload[:user].name)
```
is much nicer IMO.

Specs are coming but I wanted to start a discussion first.